### PR TITLE
Refactor API service and pagination safeguards

### DIFF
--- a/Verdantia/PlantAPIService.swift
+++ b/Verdantia/PlantAPIService.swift
@@ -4,19 +4,33 @@ import Foundation
 
 final class PlantAPIService {
     static let shared = PlantAPIService()
+    private let session: URLSession
+    private let apiKey = "YOUR_API_KEY"
+
+    private init(session: URLSession = .shared) {
+        self.session = session
+    }
 
     func fetchPlants(page: Int = 1, query: String = "") async throws -> [APIPlant] {
-        var urlString = "https://perenual.com/api/species-list?page=\(page)&key=YOUR_API_KEY"
+        var components = URLComponents(string: "https://perenual.com/api/species-list")!
+        components.queryItems = [
+            URLQueryItem(name: "page", value: String(page)),
+            URLQueryItem(name: "key", value: apiKey)
+        ]
+
         if !query.isEmpty {
-            let encodedQuery = query.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
-            urlString += "&q=\(encodedQuery)"
+            components.queryItems?.append(URLQueryItem(name: "q", value: query))
         }
 
-        guard let url = URL(string: urlString) else {
+        guard let url = components.url else {
             throw URLError(.badURL)
         }
 
-        let (data, _) = try await URLSession.shared.data(from: url)
+        let (data, response) = try await session.data(from: url)
+        guard let httpResponse = response as? HTTPURLResponse,
+              (200..<300).contains(httpResponse.statusCode) else {
+            throw URLError(.badServerResponse)
+        }
 
         #if DEBUG
         if let jsonString = String(data: data, encoding: .utf8) {

--- a/Verdantia/PlantListView.swift
+++ b/Verdantia/PlantListView.swift
@@ -25,6 +25,7 @@ struct PlantListView: View {
             } else {
                 List {
                     ForEach(viewModel.plants) { plant in
+                        let isSaved = savedPlants.contains { $0.id == plant.id }
                         HStack {
                             AsyncImage(url: URL(string: plant.default_image?.original_url ?? "")) { phase in
                                 switch phase {
@@ -54,13 +55,13 @@ struct PlantListView: View {
                             Spacer()
 
                             Button {
-                                if !savedPlants.contains(where: { $0.id == plant.id }) {
+                                if !isSaved {
                                     let saved = viewModel.convertToSavedPlant(from: plant)
                                     context.insert(saved)
                                 }
                             } label: {
-                                Image(systemName: savedPlants.contains(where: { $0.id == plant.id }) ? "heart.fill" : "heart")
-                                    .foregroundStyle(savedPlants.contains(where: { $0.id == plant.id }) ? Color.red : Color.blue)
+                                Image(systemName: isSaved ? "heart.fill" : "heart")
+                                    .foregroundStyle(isSaved ? Color.red : Color.blue)
                             }
                         }
                         .task {

--- a/Verdantia/PlantViewModel.swift
+++ b/Verdantia/PlantViewModel.swift
@@ -18,8 +18,9 @@ final class PlantViewModel: ObservableObject {
             return
         }
 
-        let thresholdIndex = plants.index(plants.endIndex, offsetBy: -5)
-        if plants.firstIndex(where: { $0.id == currentItem.id }) == thresholdIndex {
+        let thresholdIndex = max(plants.count - 5, 0)
+        if let index = plants.firstIndex(where: { $0.id == currentItem.id }),
+           index >= thresholdIndex {
             await loadNextPage(query: query)
         }
     }


### PR DESCRIPTION
## Summary
- guard against index underrun when determining pagination threshold
- refactor plant list view to compute save state once
- modernize API service with URLComponents, injectable session, and response validation

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_68942531b93c832cb89765fd8798b596